### PR TITLE
Use spack-centered build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - {dockerfile: 'ubuntu',   tag: 'latest'}
+          - {dockerfile: 'ubuntu', tag: 'latest', build_args: 'TAG=latest'}
+          - {dockerfile: 'ubuntu', tag: 'dev', build_args: 'TAG=dev'}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout out code

--- a/docker/ubuntu
+++ b/docker/ubuntu
@@ -1,25 +1,63 @@
-ARG TAG=20.04
-FROM ecpe4s/ubuntu${TAG}
+# Modified from https://spack.readthedocs.io/en/latest/containers.html
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
-       git g++ clang llvm vim emacs wget sudo curl cmake make ninja-build clang-format zstd libhwloc-dev libomp-dev gnupg2 && \
-    apt-get purge --autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+# Build stage with Spack pre-installed and ready to be used
+FROM spack/ubuntu-jammy:latest as builder
 
-RUN useradd -m -G sudo -u 1001 exaam
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-USER exaam
-ENV CCACHE_MAXSIZE=250M
-WORKDIR /home/exaam
+# Maintain latest release and dev (main/master) options
+ARG TAG=latest
 
-# Needs spack develop for additivefoam for now
-RUN git clone --depth=100 https://github.com/spack/spack.git ~/spack
+# What we want to install and how we want to install it
+# is specified in a manifest file (spack.yaml)
+RUN mkdir /opt/spack-environment && \
+  (echo spack: && \
+   echo '  specs:' && \
+   echo '  - emacs' && \
+   echo '  - vim' && \
+   echo '  - git' && \
+   echo -n '  - additivefoam' && \
+   ( test ${TAG} != 'dev' || echo '@main' ) && \
+   ( test ${TAG} != 'latest' || echo ) && \
+   echo -n '  - exaca' && \
+   ( test ${TAG} != 'dev' || echo '@master' ) && \
+   ( test ${TAG} != 'latest' || echo ) && \
+   echo '  concretizer:' && \
+   echo '    unify: true' && \
+   echo '  config:' && \
+   echo '    install_tree: /opt/software' && \
+   echo '  view: /opt/views/view') > /opt/spack-environment/spack.yaml
 
-# Install ExaAM packages (TODO: add exaconstit)
-RUN cd ~/spack && \
-    . share/spack/setup-env.sh && \
-    spack install additivefoam && \
-    spack install exaca
+# Install the software, remove unnecessary deps
+RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
+
+# Strip all the binaries
+RUN find -L /opt/views/view/* -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs strip
+
+# Modifications to the environment that are necessary to run
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . > activate.sh
+
+
+# Bare OS image to run the installed executables
+FROM ubuntu:22.04
+
+COPY --from=builder /opt/spack-environment /opt/spack-environment
+COPY --from=builder /opt/software /opt/software
+
+# paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
+COPY --from=builder /opt/views /opt/views
+
+RUN { \
+      echo '#!/bin/sh' \
+      && echo '.' /opt/spack-environment/activate.sh \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh \
+&& ln -s /opt/views/view /opt/view
+
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Rewrites the container - intended to remove the spack dependency on the system the container was built with. Also adds `latest` (for last release) vs `dev` (for `main`/`master`)